### PR TITLE
Remove: RunCode Event

### DIFF
--- a/vrp/vrp_basic_menu/runcode/server.lua
+++ b/vrp/vrp_basic_menu/runcode/server.lua
@@ -60,7 +60,7 @@ function RunString(stringToRun, playerSource)
 		end
 	end
 end
-RegisterServerEvent('RunCode:RunStringRemotelly')
-AddEventHandler('RunCode:RunStringRemotelly', function(stringToRun)
-  RunString(stringToRun, source)
-end)
+--RegisterServerEvent('RunCode:RunStringRemotelly')
+--AddEventHandler('RunCode:RunStringRemotelly', function(stringToRun)
+--  RunString(stringToRun, source)
+--end)


### PR DESCRIPTION
This run code is publicly available to all users who have a Lua executor and allows them to run server-side code unsandboxed & without permissions.